### PR TITLE
Fixes the version in the podspec

### DIFF
--- a/MTGSDKSwift.podspec
+++ b/MTGSDKSwift.podspec
@@ -5,7 +5,7 @@
 
  Pod::Spec.new do |s|
   s.name             = 'MTGSDKSwift'
-  s.version          = '1.0.1'
+  s.version          = '1.1'
   s.summary          = 'Magic: The Gathering SDK - Swift'
   s.description      = <<-DESC
   A lightweight framework that makes interacting with the magicthegathering.io api quick, easy and safe.


### PR DESCRIPTION
### Background
The current 1.1 tagged (1382dce) podspec has a version of 1.0.1, but should be 1.1.

After merging this PR, we should re-tag 1.1 to be this new version.

### Checklist
- [x] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
