### PR TITLE
add swift concurrency support for fetch cards request

### DIFF
--- a/MTGSDKSwift.xcodeproj/project.pbxproj
+++ b/MTGSDKSwift.xcodeproj/project.pbxproj
@@ -576,6 +576,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = MTGSDKSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwift;
@@ -597,6 +598,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = MTGSDKSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwift;

--- a/MTGSDKSwift.xcodeproj/project.pbxproj
+++ b/MTGSDKSwift.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 				DEVELOPMENT_TEAM = X68KF89T7U;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TestApplication/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwift.Test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -457,7 +457,7 @@
 				DEVELOPMENT_TEAM = X68KF89T7U;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = TestApplication/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwift.Test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -615,6 +615,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = X68KF89T7U;
 				INFOPLIST_FILE = MTGSDKSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -629,6 +630,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = X68KF89T7U;
 				INFOPLIST_FILE = MTGSDKSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MTGSDKSwift/MTGAPIService.swift
+++ b/MTGSDKSwift/MTGAPIService.swift
@@ -44,7 +44,6 @@ final class MTGAPIService {
         }
     }
     
-    @available(iOS 15.0, *)
     func mtgAPIQuery<T: ResponseObject>(url: URL, responseObject: T.Type) async throws -> T {
         let networkOperation = NetworkOperation(url: url)
         
@@ -111,7 +110,6 @@ final private class NetworkOperation {
         }.resume()
     }
     
-    @available(iOS 15.0, *)
     func performOperation() async throws -> Data {
         let (data, response) = try await URLSession.shared.data(for: URLRequest(url: url))
         

--- a/MTGSDKSwift/MagicalCardManager.swift
+++ b/MTGSDKSwift/MagicalCardManager.swift
@@ -55,7 +55,6 @@ final public class Magic {
     ///   - parameters: The Card Search Parameters that you'd like to search with.
     ///   - configuration: The Search Configuration (defaults to `.defaultConfiguration`).
     ///   - completion: The completion handler (for success / failure response).
-    @available(iOS 15.0, *)
     public func fetchCards(_ parameters: [CardSearchParameter],
                            configuration: MTGSearchConfiguration = .defaultConfiguration) async throws -> [Card] {
         guard let url = URLBuilder.buildURLWithParameters(parameters, andConfig: configuration) else {

--- a/MTGSDKSwift/MagicalCardManager.swift
+++ b/MTGSDKSwift/MagicalCardManager.swift
@@ -54,7 +54,6 @@ final public class Magic {
     /// - Parameters:
     ///   - parameters: The Card Search Parameters that you'd like to search with.
     ///   - configuration: The Search Configuration (defaults to `.defaultConfiguration`).
-    ///   - completion: The completion handler (for success / failure response).
     public func fetchCards(_ parameters: [CardSearchParameter],
                            configuration: MTGSearchConfiguration = .defaultConfiguration) async throws -> [Card] {
         guard let url = URLBuilder.buildURLWithParameters(parameters, andConfig: configuration) else {

--- a/MTGSDKSwift/MagicalCardManager.swift
+++ b/MTGSDKSwift/MagicalCardManager.swift
@@ -48,6 +48,23 @@ final public class Magic {
         }
     }
     
+    /// Retrieves an array of Cards which match the parameters given using Swift concurrency and utilizes `async await`.
+    /// See https://docs.magicthegathering.io/#api_v1cards_list for more info.
+    ///
+    /// - Parameters:
+    ///   - parameters: The Card Search Parameters that you'd like to search with.
+    ///   - configuration: The Search Configuration (defaults to `.defaultConfiguration`).
+    ///   - completion: The completion handler (for success / failure response).
+    @available(iOS 15.0, *)
+    public func fetchCards(_ parameters: [CardSearchParameter],
+                           configuration: MTGSearchConfiguration = .defaultConfiguration) async throws -> [Card] {
+        guard let url = URLBuilder.buildURLWithParameters(parameters, andConfig: configuration) else {
+            throw NetworkError.miscError("fetchCards URL build failed")
+        }
+        
+        return try await mtgAPIService.mtgAPIQuery(url: url, responseObject: CardsResponse.self).cards
+    }
+    
     /// Reteives an array of CardSet which matches the parameters given.
     /// See https://docs.magicthegathering.io/#api_v1sets_list for more info.
     ///


### PR DESCRIPTION
### Background

- Increment minimum iOS Deployment target from `10.2` to `15.0`.
- Add support for an `async await` `fetchCards` api.

### Breaking Changes

None

### Checklist

- [x] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [x] Documentation has been added to all `open`, `public`, and `internal` scoped methods and properties.
- [ ] Tests have have been added to all new features.
- [ ] Image/GIFs have been added for all UI related changed.

