### PR TITLE
Added support for MacOS with AppKit

### DIFF
--- a/MTGSDKSwift.podspec
+++ b/MTGSDKSwift.podspec
@@ -17,6 +17,7 @@
   s.source           = { :git => 'https://github.com/MagicTheGathering/mtg-sdk-swift.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '10.2'
+  s.osx.deployment_target  = '12.4'
   s.source_files = 'MTGSDKSwift/**/*.swift'
   s.swift_version = '4.1'
  end

--- a/MTGSDKSwift.xcodeproj/project.pbxproj
+++ b/MTGSDKSwift.xcodeproj/project.pbxproj
@@ -116,6 +116,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		073F02172CCFC58D00AF05D1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		5B6092D5215EA5F400CDD46A /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -146,6 +153,7 @@
 				5B87D68520596D6B0098553C /* TestApplication */,
 				5BD04DAA1E64943C00E5ED27 /* Products */,
 				5B6092D5215EA5F400CDD46A /* Recovered References */,
+				073F02172CCFC58D00AF05D1 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -577,13 +585,22 @@
 				INFOPLIST_FILE = MTGSDKSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.4;
 				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -599,13 +616,22 @@
 				INFOPLIST_FILE = MTGSDKSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.4;
 				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -619,8 +645,12 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -634,8 +664,12 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rpcarson.MTGSDKSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/MTGSDKSwift.xcodeproj/xcshareddata/xcschemes/MTGSDKSwift.xcscheme
+++ b/MTGSDKSwift.xcodeproj/xcshareddata/xcschemes/MTGSDKSwift.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5BD04DA81E64943C00E5ED27"
+            BuildableName = "MTGSDKSwift.framework"
+            BlueprintName = "MTGSDKSwift"
+            ReferencedContainer = "container:MTGSDKSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5BD04DA81E64943C00E5ED27"
-            BuildableName = "MTGSDKSwift.framework"
-            BlueprintName = "MTGSDKSwift"
-            ReferencedContainer = "container:MTGSDKSwift.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:MTGSDKSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MTGSDKSwift/MTGAPIService.swift
+++ b/MTGSDKSwift/MTGAPIService.swift
@@ -44,6 +44,7 @@ final class MTGAPIService {
         }
     }
     
+    @available(iOS 15.0, *)
     func mtgAPIQuery<T: ResponseObject>(url: URL, responseObject: T.Type) async throws -> T {
         let networkOperation = NetworkOperation(url: url)
         
@@ -110,6 +111,7 @@ final private class NetworkOperation {
         }.resume()
     }
     
+    @available(iOS 15.0, *)
     func performOperation() async throws -> Data {
         let (data, response) = try await URLSession.shared.data(for: URLRequest(url: url))
         

--- a/MTGSDKSwift/MTGSDKSwift.h
+++ b/MTGSDKSwift/MTGSDKSwift.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Reed Carson. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for MTGSDKSwift.
 FOUNDATION_EXPORT double MTGSDKSwiftVersionNumber;

--- a/MTGSDKSwift/MagicalCardManager.swift
+++ b/MTGSDKSwift/MagicalCardManager.swift
@@ -56,6 +56,7 @@ final public class Magic {
     /// - Parameters:
     ///   - parameters: The Card Search Parameters that you'd like to search with.
     ///   - configuration: The Search Configuration (defaults to `.defaultConfiguration`).
+    @available(iOS 15.0, *)
     public func fetchCards(_ parameters: [CardSearchParameter],
                            configuration: MTGSearchConfiguration = .defaultConfiguration) async throws -> [Card] {
         guard let url = URLBuilder.buildURLWithParameters(parameters, andConfig: configuration) else {

--- a/MTGSDKSwift/MagicalCardManager.swift
+++ b/MTGSDKSwift/MagicalCardManager.swift
@@ -5,11 +5,13 @@
 //  Created by Reed Carson on 3/1/17.
 //  Copyright © 2017 Reed Carson. All rights reserved.
 //
-
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
 import UIKit
+#endif
 
 final public class Magic {
-    public typealias CardImageCompletion = (Result<UIImage>) -> Void
     public typealias CardCompletion = (Result<[Card]>) -> Void
     public typealias SetCompletion = (Result<[CardSet]>) -> Void
 
@@ -116,6 +118,9 @@ final public class Magic {
         }
     }
     
+#if canImport(UIKit)
+    public typealias CardImageCompletion = (Result<UIImage>) -> Void
+    
     /// Retreives a UIImage based on the imageURL of the Card passed in
     ///
     /// - Parameters:
@@ -140,7 +145,37 @@ final public class Magic {
             completion(Result.error(NetworkError.fetchCardImageError("data from contents of url failed")))
         }
     }
-
+#endif
+    
+#if canImport(AppKit)
+    public typealias CardImageCompletion = (Result<NSImage>) -> Void
+    
+    /// Retreives a NSImage based on the imageURL of the Card passed in
+    ///
+    /// - Parameters:
+    ///   - card: The card you wish to get the image for.
+    ///   - completion: The completion handler (for success / failure response).
+    public func fetchImageForCard(_ card: Card, completion: @escaping CardImageCompletion) {
+        guard let imgurl = card.imageUrl else {
+            return completion(Result.error(NetworkError.fetchCardImageError("fetchImageForCard card imageURL was nil")))
+        }
+        
+        guard let url = URL(string: imgurl) else {
+            return completion(Result.error(NetworkError.fetchCardImageError("fetchImageForCard url build failed")))
+        }
+        
+        do {
+            let data = try Data(contentsOf: url)
+            guard let img = NSImage(data: data) else {
+                return completion(Result.error(NetworkError.fetchCardImageError("could not create uiimage from data")))
+            }
+            completion(Result.success(img))
+        } catch {
+            completion(Result.error(NetworkError.fetchCardImageError("data from contents of url failed")))
+        }
+    }
+#endif
+    
     /// This function simulates opening a booster pack for the given set, producing an array of [Card]
     ///
     /// - Parameters:

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MTGSDKSwift",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v15),
         .macOS(.v12)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "MTGSDKSwift",
     platforms: [
-        .iOS(.v9)
+        .iOS(.v9),
+        .macOS(.v12)
     ],
     products: [
         .library(


### PR DESCRIPTION
### Background
When trying to add the package to a multiplatform or MacOS project it is not possibile to compile as it requires `UIKit`. This PR adds new handlers for handling code on MacOS with `AppKit`

### Breaking Changes
Package does not support iOS 9 anymore but in any case the project only works with iOS 15+ so it should be more correct like this

### Checklist

- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [x] Documentation has been added to all `open`, `public`, and `internal` scoped methods and properties.
- [ ] Tests have have been added to all new features.
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->
